### PR TITLE
Don't strip px values from some CSS values

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -65,6 +65,7 @@ export const svgCoerceToBooleanAttributes = [
 
 // These are HTML attributes that must be positive numbers.
 export const numberAttributes = [
+  "border",
   "cellPadding",
   "cellSpacing",
   "cols",
@@ -253,6 +254,8 @@ export const lowercasedAttributes = [
   "charSet",
   "classID",
   "colSpan",
+  "cellSpacing",
+  "cellMargin",
   "contextMenu",
   "controlsList",
   "crossOrigin",
@@ -274,3 +277,11 @@ export const lowercasedAttributes = [
   "srcSet",
   "useMap",
 ];
+
+/**
+ * Don't strip the px suffix from these style attributes
+ */
+export const styleDontStripPx = [
+  'line-height',
+  'font-size',
+]

--- a/src/convert-attributes.ts
+++ b/src/convert-attributes.ts
@@ -25,6 +25,7 @@ import {
   lowercasedAttributes,
   numberAttributes,
   renamedAttributes,
+  styleDontStripPx,
   svgCamelizedAttributes,
   svgCoerceToBooleanAttributes,
 } from "./attributes";
@@ -113,12 +114,13 @@ function convertStyleToObjectExpression(style: string) {
   const properties: Array<ObjectProperty> = [];
 
   parseStyleString(style, (name, value) => {
+    // Don't remove `px` where this changes the meaning of the attribute value
+    const canStripPx = !styleDontStripPx.includes(name.toLowerCase());
     const pxValueMatch = value.match(MATCH_PX_VALUE);
-
     properties.push(
       objectProperty(
         identifier(camelize(name)),
-        pxValueMatch !== null
+        pxValueMatch !== null && canStripPx
           ? numericLiteral(Number(pxValueMatch[1]))
           : stringLiteral(value)
       )

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -100,6 +100,13 @@ test("converts style tag including px values to numbers", () => {
   </h1>`);
 });
 
+test("px values are not converted for specified CSS attributes", () => {
+  const htmlToConvert = html`<h1 style="line-height: 14px; font-size: 16px;">Hello World!</h1>`;
+  const convertedJSX = htmlToJsx(htmlToConvert);
+  expect(convertedJSX)
+    .toBe(`<h1 style={{ lineHeight: "14px", fontSize: "16px" }}>Hello World!</h1>`)
+});
+
 test("works with adjacent elements", () => {
   const htmlToConvert = html`
     <h1>Hello</h1>
@@ -308,6 +315,14 @@ test("false boolean attributes get converted to boolean expression", () => {
 
   expect(convertedJSX).toBe(`<input checked={false} />`);
 });
+
+test("border attributes are converted to numbers", () => {
+  const htmlToConvert = `<table border="0"></table>`;
+
+  const convertedJSX = htmlToJsx(htmlToConvert);
+  
+  expect(convertedJSX).toBe(`<table border={0} />`);
+})
 
 test("boolean attributes with non-boolean values are left untouched", () => {
   const htmlToConvert = html`<a href="example.com" download="installer.exe"


### PR DESCRIPTION
This PR stops `px` being stripped from some CSS values, as this changes the meaning of the value. For example, [a numeric value specified](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height) for `line-height` without a unit multiplies by the element's font-size, which is not the same behaviour. For `font-size`, the specification does not say what would happen if you remove the unit. 

[Removing units is really only permitted](https://developer.mozilla.org/en-US/docs/Web/CSS/length) for `0` lengths, so if this behaviour should be removed altogether?

I've also added some (now deprecated but still used) HTML attributes that have to be converted to numbers to satisfy React types.