### PR TITLE
Merge tag extract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/generator": "^7.19.0",
         "@babel/parser": "^7.19.1",
         "@babel/types": "^7.19.0",
+        "html-entities": "^2.3.3",
         "parse5": "^7.1.1",
         "style-to-object": "^0.3.0"
       },
@@ -1944,6 +1945,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5354,6 +5360,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/generator": "^7.19.0",
     "@babel/parser": "^7.19.1",
     "@babel/types": "^7.19.0",
+    "html-entities": "^2.3.3",
     "parse5": "^7.1.1",
     "style-to-object": "^0.3.0"
   },

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -423,13 +423,13 @@ test("Example with merge tags", () => {
   const convertedJSX = htmlToJsx(htmlToConvert);
 
   expect(convertedJSX).toBe(
-    `<><script type="text/x-merge-tag">{\`{% if email %}\`}</script>
+    `<>{ /*$merge: {% if email %}*/ }
     <button className="max-w-8">
       <span>Send Email</span>
     </button>
-    <script type="text/x-merge-tag">{\`{% else %}\`}</script>
+    { /*$merge: {% else %}*/ }
     <button className="max-w-8 bg-blue"><span>Call</span></button>
-    <script type="text/x-merge-tag">{\`{% /if %}\`}</script></>`
+    { /*$merge: {% /if %}*/ }</>`
   );
 });
 
@@ -438,9 +438,7 @@ test("Merge tag at top-level", () => {
 
   const convertedJSX = htmlToJsx(htmlToConvert);
 
-  expect(convertedJSX).toBe(
-    `<script type="text/x-merge-tag">{\`{{ email | to_lower() }}\`}</script>`
-  );
+  expect(convertedJSX).toBe(`{ /*$merge: {{ email | to_lower() }}*/ }`);
 });
 
 test("HTML entities are preserved in JSX text", () => {
@@ -458,7 +456,7 @@ test("HTML entities are preserved in JSX text", () => {
 test("HTML entities are not created in string literals or template literals", () => {
   expect(htmlToJsx(`some&nbsp;text`)).toEqual(`"some\\xA0text"`);
   expect(htmlToJsx(`your email is "{{ email ++ "\xA0" }}"`)).toEqual(
-    `<>your email is &quot;<script type="text/x-merge-tag">{\`{{ email ++ "\xA0" }}\`}</script>&quot;</>`
+    `<>your email is &quot;{ /*$merge: {{ email ++ "\xA0" }}*/ }&quot;</>`
   );
   expect(htmlToJsx(`<style>background-color: blue;</style>`)).toEqual(
     `<style>{\`background-color: blue;\`}</style>`

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -440,7 +440,7 @@ test("HTML entities are not created in string literals or template literals", ()
   expect(htmlToJsx(`your email is "{{ email ++ "\xA0" }}"`)).toEqual(
     `<>your email is &quot;<script type="text/x-merge-tag">{\`{{ email ++ "\xA0" }}\`}</script>&quot;</>`
   );
-  expect(htmlToJsx(`<style>background-color: blue;</style`)).toEqual(
-    `<style>{\`background-color: blue;\`}`
+  expect(htmlToJsx(`<style>background-color: blue;</style>`)).toEqual(
+    `<style>{\`background-color: blue;\`}</style>`
   );
 });

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -388,3 +388,27 @@ test("Tailwind CSS sample works", () => {
     </button>`
   );
 });
+
+test("Example with merge tags", () => {
+  const htmlToConvert = html`
+    {% if email %}
+    <button class="max-w-8">
+      <span>Send Email</span>
+    </button>
+    {% else %}
+    <button class="max-w-8 bg-blue"><span>Call</span></button>
+    {% /if %}
+  `;
+
+  const convertedJSX = htmlToJsx(htmlToConvert);
+
+  expect(convertedJSX).toBe(
+    `<><script type="text/x-merge-tag">{\`{% if email %}\`}</script>
+    <button className="max-w-8">
+      <span>Send Email</span>
+    </button>
+    <script type="text/x-merge-tag">{\`{% else %}\`}</script>
+    <button className="max-w-8 bg-blue"><span>Call</span></button>
+    <script type="text/x-merge-tag">{\`{% /if %}\`}</script></>`
+  );
+});

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -412,3 +412,13 @@ test("Example with merge tags", () => {
     <script type="text/x-merge-tag">{\`{% /if %}\`}</script></>`
   );
 });
+
+test("Merge tag at top-level", () => {
+  const htmlToConvert = html`{{ email | to_lower() }}`;
+
+  const convertedJSX = htmlToJsx(htmlToConvert);
+
+  expect(convertedJSX).toBe(
+    `<script type="text/x-merge-tag">{\`{{ email | to_lower() }}\`}</script>`
+  );
+});

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -440,7 +440,7 @@ test("HTML entities are not created in string literals or template literals", ()
   expect(htmlToJsx(`your email is "{{ email ++ "\xA0" }}"`)).toEqual(
     `<>your email is &quot;<script type="text/x-merge-tag">{\`{{ email ++ "\xA0" }}\`}</script>&quot;</>`
   );
-  expect(htmlToJsx(`<style type="text/css">background-color: blue;</style>`)).toEqual(
-    `<style type="text/css">{\`background-color: blue;\`}</style>`
+  expect(htmlToJsx(`<style>background-color: blue;</style`)).toEqual(
+    `<style>{\`background-color: blue;\`}`
   );
 });

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -422,3 +422,25 @@ test("Merge tag at top-level", () => {
     `<script type="text/x-merge-tag">{\`{{ email | to_lower() }}\`}</script>`
   );
 });
+
+test("HTML entities are preserved in JSX text", () => {
+  const htmlToConvert = html`<span
+    >This has&nbsp;a non-breaking space and a &lt; symbol</span
+  >`;
+
+  const convertedJSX = htmlToJsx(htmlToConvert);
+
+  expect(convertedJSX).toBe(
+    `<span>This has&nbsp;a non-breaking space and a &lt; symbol</span>`
+  );
+});
+
+test("HTML entities are not created in string literals or template literals", () => {
+  expect(htmlToJsx(`some&nbsp;text`)).toEqual(`"some\\xA0text"`);
+  expect(htmlToJsx(`your email is "{{ email ++ "\xA0" }}"`)).toEqual(
+    `<>your email is &quot;<script type="text/x-merge-tag">{\`{{ email ++ "\xA0" }}\`}</script>&quot;</>`
+  );
+  expect(htmlToJsx(`<style type="text/css">background-color: blue;</style>`)).toEqual(
+    `<style type="text/css">{\`background-color: blue;\`}</style>`
+  );
+});

--- a/src/html-to-jsx.ts
+++ b/src/html-to-jsx.ts
@@ -36,7 +36,6 @@ import { splitMergeTags } from "./split-merge-tags";
 
 export function htmlToJsx(html: string): string {
   const htmlAst = parseFragment(html.trim());
-  console.log(htmlAst?.childNodes?.[0]);
 
   let babelAst: ExpressionStatement;
   if (htmlAst.childNodes.length === 1) {

--- a/src/split-merge-tags.test.ts
+++ b/src/split-merge-tags.test.ts
@@ -1,0 +1,66 @@
+import { splitMergeTags } from "./split-merge-tags";
+
+test("splitMergeTags returns a single part for a string containing no merge tags", () => {
+  expect(splitMergeTags("This is some text")).toEqual([
+    {
+      type: "string",
+      value: "This is some text",
+    },
+  ]);
+});
+
+test("splitMergeTags handles an empty string", () => {
+  expect(splitMergeTags("")).toEqual([]);
+});
+
+test("splitMergeTags handles merge tags aligned to boundaries", () => {
+  expect(splitMergeTags("{% something here%}")).toEqual([
+    {
+      type: "merge",
+      value: "{% something here%}",
+    },
+  ]);
+});
+
+test("splitMergeTags handles merge tags not at boundaries", () => {
+  expect(splitMergeTags("some text {% email %} around a merge tag")).toEqual([
+    { type: "string", value: "some text " },
+    { type: "merge", value: "{% email %}" },
+    { type: "string", value: " around a merge tag" },
+  ]);
+});
+
+test("splitMergeTags handles merge tags at one boundary", () => {
+  expect(splitMergeTags("{% email %} around a merge tag")).toEqual([
+    { type: "merge", value: "{% email %}" },
+    { type: "string", value: " around a merge tag" },
+  ]);
+  expect(splitMergeTags("some text {% email %}")).toEqual([
+    { type: "string", value: "some text " },
+    { type: "merge", value: "{% email %}" },
+  ]);
+});
+
+test("splitMergeTags handles multiple merge tags in a string", () => {
+  expect(
+    splitMergeTags("this is my { email } and this is my {{phoneNumber }}")
+  ).toEqual([
+    { type: "string", value: "this is my " },
+    { type: "merge", value: "{ email }" },
+    { type: "string", value: " and this is my " },
+    { type: "merge", value: "{{phoneNumber }}" },
+  ]);
+});
+
+test("splitMergeTags handles escaped merge tag characters", () => {
+  expect(
+    splitMergeTags(
+      "this is my { '\\{' + email } and this is my {{phoneNumber }}"
+    )
+  ).toEqual([
+    { type: "string", value: "this is my " },
+    { type: "merge", value: "{ '\\{' + email }" },
+    { type: "string", value: " and this is my " },
+    { type: "merge", value: "{{phoneNumber }}" },
+  ]);
+});

--- a/src/split-merge-tags.test.ts
+++ b/src/split-merge-tags.test.ts
@@ -64,3 +64,16 @@ test("splitMergeTags handles escaped merge tag characters", () => {
     { type: "merge", value: "{{phoneNumber }}" },
   ]);
 });
+
+test("splitMergeTags handles escaped merge tag characters", () => {
+  expect(
+    splitMergeTags(
+      "this is my { '\\{' + email } and this is my {{phoneNumber }}"
+    )
+  ).toEqual([
+    { type: "string", value: "this is my " },
+    { type: "merge", value: "{ '\\{' + email }" },
+    { type: "string", value: " and this is my " },
+    { type: "merge", value: "{{phoneNumber }}" },
+  ]);
+});

--- a/src/split-merge-tags.ts
+++ b/src/split-merge-tags.ts
@@ -1,0 +1,29 @@
+export function splitMergeTags(str: string) {
+  let bal = 0;
+  const parts: { value: string; type: "string" | "merge" }[] = [];
+  let part = "";
+  const pushStringPart = (part: string) =>
+    part.length > 0 && parts.push({ type: "string" as const, value: part });
+  for (let i = 0; i < str.length; i++) {
+    let c = str[i];
+    if (c === "{" && str[i - 1] !== "\\") {
+      if (bal === 0) {
+        pushStringPart(part);
+        part = "";
+      }
+      part += c;
+      bal += 1;
+    } else if (c === "}" && str[i - 1] !== "\\") {
+      bal -= 1;
+      part += c;
+      if (bal === 0) {
+        parts.push({ type: "merge" as const, value: part });
+        part = "";
+      }
+    } else {
+      part += c;
+    }
+  }
+  pushStringPart(part);
+  return parts;
+}

--- a/src/split-merge-tags.ts
+++ b/src/split-merge-tags.ts
@@ -1,3 +1,5 @@
+export type TextPart = { value: string; type: "string" | "merge" };
+
 /**
  * Split a string into parts based on the presence
  * of merge tags (`{ ... }`).
@@ -17,7 +19,7 @@
  */
 export function splitMergeTags(str: string) {
   let bal = 0;
-  const parts: { value: string; type: "string" | "merge" }[] = [];
+  const parts: TextPart[] = [];
   let part = "";
   const pushStringPart = (part: string) =>
     part.length > 0 && parts.push({ type: "string" as const, value: part });

--- a/src/split-merge-tags.ts
+++ b/src/split-merge-tags.ts
@@ -1,3 +1,20 @@
+/**
+ * Split a string into parts based on the presence
+ * of merge tags (`{ ... }`).
+ *
+ * Each string component has `type: 'string'` while
+ * the merge tag components has `type: 'merge'`. The
+ * merge tags are preserved in the string.
+ *
+ * If there are no merge tags, the string is returned
+ * single element array of `type: 'string'`.
+ *
+ * When the input text is the empty string, a zero-length
+ * array is returned.
+ *
+ * @param str the string to split up
+ * @returns an array of string parts, classed as `string` or `merge`
+ */
 export function splitMergeTags(str: string) {
   let bal = 0;
   const parts: { value: string; type: "string" | "merge" }[] = [];


### PR DESCRIPTION
This is perhaps a more contentious change than the last PR (#1). It looks for merge tags from templating frameworks (I have a lot of source HTML with them inside from handlebars, liquidjs, etc).

Merge tags are typically delineated by braces (i.e. `{ .. }`). This change puts them inside script tags so they don't break the JSX that is generated.