### PR TITLE
fix: skip css variable, it should not be processed

### DIFF
--- a/src/convert-attributes.ts
+++ b/src/convert-attributes.ts
@@ -133,10 +133,16 @@ function convertStyleToObjectExpression(style: string) {
 const CAMELIZE = /[\-\:]([a-z])/g;
 const capitalize = (token: string) => token[1]!.toUpperCase();
 
+const IS_CSS_VARIBLE = /^--\w+/
+
 /**
  * Converts kebab-case or colon:case to camelCase
  */
 function camelize(string: string) {
+  // Skip the attribute if it is a css variable.
+  // It looks something like this: style="--bgColor: red"
+  if (IS_CSS_VARIBLE.test(string))
+    return `"${string}"`
   return string.replace(CAMELIZE, capitalize);
 }
 

--- a/src/html-to-jsx.test.ts
+++ b/src/html-to-jsx.test.ts
@@ -462,3 +462,8 @@ test("HTML entities are not created in string literals or template literals", ()
     `<style>{\`background-color: blue;\`}</style>`
   );
 });
+
+test("Css varibles should not be processed", () => {
+  const htmlToConvert = html`<div class="container" style="width: 12px; height: 30px; --bg-color: red;" />`
+  expect(htmlToJsx(htmlToConvert)).toEqual('<div className="container" style={{ width: 12, height: 30, "--bg-color": "red" }} />')
+})


### PR DESCRIPTION
Some dependencies use css variables, such as [shiki](https://github.com/shikijs/shiki). If we deal with it, this is not right. The result will look something like `--shiki-dark` --> `-ShikiDark`.